### PR TITLE
Remove redundant emit call

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ const koa404Handler = async (ctx, next) => {
     if (ctx.status === 404) ctx.throw(404);
   } catch (err) {
     ctx.throw(err);
-    ctx.app.emit('error', err, ctx);
   }
 };
 


### PR DESCRIPTION
As ctx.throw() throws an exception, we will never return from the call and emit() is never called. Thus, it can be removed entirely.

Fixes #4